### PR TITLE
fix: Add entity_id targeting to all service schemas

### DIFF
--- a/custom_components/pianobar/__init__.py
+++ b/custom_components/pianobar/__init__.py
@@ -49,12 +49,13 @@ def _get_coordinator_from_call(
     call: ServiceCall
 ) -> PianobarCoordinator:
     """Get coordinator from service call target or default to first instance."""
-    # Try to get entity_id from target
-    entity_ids = call.data.get("entity_id")
+    # Extract entity_id - HA puts it in call.data when using targets
+    entity_id = call.data.get("entity_id")
     
-    if entity_ids:
-        # Use first entity if multiple provided
-        entity_id = entity_ids[0] if isinstance(entity_ids, list) else entity_ids
+    if entity_id:
+        # Handle both single entity and list
+        if isinstance(entity_id, list):
+            entity_id = entity_id[0]
         
         # Look up entity to get its entry_id
         entity_registry = er.async_get(hass)
@@ -287,21 +288,27 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         DOMAIN,
         SERVICE_LOVE_SONG,
         async_love_song,
-        schema=vol.Schema({}),
+        schema=vol.Schema({
+            vol.Optional("entity_id"): cv.entity_ids,
+        }),
     )
 
     hass.services.async_register(
         DOMAIN,
         SERVICE_BAN_SONG,
         async_ban_song,
-        schema=vol.Schema({}),
+        schema=vol.Schema({
+            vol.Optional("entity_id"): cv.entity_ids,
+        }),
     )
 
     hass.services.async_register(
         DOMAIN,
         SERVICE_TIRED_OF_SONG,
         async_tired_of_song,
-        schema=vol.Schema({}),
+        schema=vol.Schema({
+            vol.Optional("entity_id"): cv.entity_ids,
+        }),
     )
 
     hass.services.async_register(
@@ -309,6 +316,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         SERVICE_CREATE_STATION,
         async_create_station,
         schema=vol.Schema({
+            vol.Optional("entity_id"): cv.entity_ids,
             vol.Optional("type", default="song"): cv.string,
         }),
     )
@@ -318,6 +326,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         SERVICE_RENAME_STATION,
         async_rename_station,
         schema=vol.Schema({
+            vol.Optional("entity_id"): cv.entity_ids,
             vol.Required("station_id"): cv.string,
             vol.Required("name"): cv.string,
         }),
@@ -328,6 +337,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         SERVICE_DELETE_STATION,
         async_delete_station,
         schema=vol.Schema({
+            vol.Optional("entity_id"): cv.entity_ids,
             vol.Required("station_id"): cv.string,
         }),
     )
@@ -336,14 +346,18 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         DOMAIN,
         SERVICE_RECONNECT,
         async_reconnect,
-        schema=vol.Schema({}),
+        schema=vol.Schema({
+            vol.Optional("entity_id"): cv.entity_ids,
+        }),
     )
 
     hass.services.async_register(
         DOMAIN,
         SERVICE_EXPLAIN_SONG,
         async_explain_song,
-        schema=vol.Schema({}),
+        schema=vol.Schema({
+            vol.Optional("entity_id"): cv.entity_ids,
+        }),
         supports_response="optional",
     )
 
@@ -351,7 +365,9 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         DOMAIN,
         SERVICE_GET_UPCOMING,
         async_get_upcoming,
-        schema=vol.Schema({}),
+        schema=vol.Schema({
+            vol.Optional("entity_id"): cv.entity_ids,
+        }),
         supports_response="optional",
     )
 
@@ -360,6 +376,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         SERVICE_SET_QUICK_MIX,
         async_set_quick_mix,
         schema=vol.Schema({
+            vol.Optional("entity_id"): cv.entity_ids,
             vol.Required("station_ids"): [cv.string],
         }),
     )
@@ -369,6 +386,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         SERVICE_ADD_SEED,
         async_add_seed,
         schema=vol.Schema({
+            vol.Optional("entity_id"): cv.entity_ids,
             vol.Required("music_id"): cv.string,
             vol.Required("station_id"): cv.string,
         }),
@@ -379,6 +397,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         SERVICE_GET_STATION_INFO,
         async_get_station_info,
         schema=vol.Schema({
+            vol.Optional("entity_id"): cv.entity_ids,
             vol.Required("station_id"): cv.string,
         }),
         supports_response="optional",
@@ -389,6 +408,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         SERVICE_DELETE_SEED,
         async_delete_seed,
         schema=vol.Schema({
+            vol.Optional("entity_id"): cv.entity_ids,
             vol.Required("seed_id"): cv.string,
             vol.Required("seed_type"): vol.In(["artist", "song", "station"]),
             vol.Required("station_id"): cv.string,
@@ -400,6 +420,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         SERVICE_DELETE_FEEDBACK,
         async_delete_feedback,
         schema=vol.Schema({
+            vol.Optional("entity_id"): cv.entity_ids,
             vol.Required("feedback_id"): cv.string,
             vol.Required("station_id"): cv.string,
         }),
@@ -410,6 +431,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         SERVICE_GET_STATION_MODES,
         async_get_station_modes,
         schema=vol.Schema({
+            vol.Optional("entity_id"): cv.entity_ids,
             vol.Required("station_id"): cv.string,
         }),
         supports_response="optional",
@@ -420,6 +442,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         SERVICE_SET_STATION_MODE,
         async_set_station_mode,
         schema=vol.Schema({
+            vol.Optional("entity_id"): cv.entity_ids,
             vol.Required("station_id"): cv.string,
             vol.Required("mode_id"): vol.Coerce(int),
         }),
@@ -429,14 +452,18 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         DOMAIN,
         SERVICE_TOGGLE_PLAYBACK,
         async_toggle_playback,
-        schema=vol.Schema({}),
+        schema=vol.Schema({
+            vol.Optional("entity_id"): cv.entity_ids,
+        }),
     )
 
     hass.services.async_register(
         DOMAIN,
         SERVICE_RESET_VOLUME,
         async_reset_volume,
-        schema=vol.Schema({}),
+        schema=vol.Schema({
+            vol.Optional("entity_id"): cv.entity_ids,
+        }),
     )
 
     hass.services.async_register(
@@ -444,6 +471,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         SERVICE_SEARCH,
         async_search,
         schema=vol.Schema({
+            vol.Optional("entity_id"): cv.entity_ids,
             vol.Required("query"): cv.string,
         }),
         supports_response="optional",
@@ -453,7 +481,9 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         DOMAIN,
         SERVICE_GET_GENRES,
         async_get_genres,
-        schema=vol.Schema({}),
+        schema=vol.Schema({
+            vol.Optional("entity_id"): cv.entity_ids,
+        }),
         supports_response="optional",
     )
 
@@ -462,6 +492,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         SERVICE_CREATE_STATION_FROM_MUSIC_ID,
         async_create_station_from_music_id,
         schema=vol.Schema({
+            vol.Optional("entity_id"): cv.entity_ids,
             vol.Required("music_id"): cv.string,
         }),
     )
@@ -471,6 +502,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         SERVICE_ADD_SHARED_STATION,
         async_add_shared_station,
         schema=vol.Schema({
+            vol.Optional("entity_id"): cv.entity_ids,
             vol.Required("station_id"): cv.string,
         }),
     )

--- a/custom_components/pianobar/coordinator.py
+++ b/custom_components/pianobar/coordinator.py
@@ -340,6 +340,8 @@ class PianobarCoordinator(DataUpdateCoordinator):
     async def wait_for_response(self, key: str, timeout: float = 5.0) -> Any:
         """Wait for response data with timeout."""
         import asyncio
+        # Clear any stale data for this key before waiting for fresh response
+        self._response_data.pop(key, None)
         start_time = asyncio.get_event_loop().time()
         while asyncio.get_event_loop().time() - start_time < timeout:
             if key in self._response_data:

--- a/custom_components/pianobar/services.yaml
+++ b/custom_components/pianobar/services.yaml
@@ -1,37 +1,21 @@
 love_song:
   name: Love song
   description: Give the current song a thumbs up
-  target:
-    entity:
-      integration: pianobar
-      domain: media_player
   fields: {}
 
 ban_song:
   name: Ban song
   description: Give the current song a thumbs down (removes from station)
-  target:
-    entity:
-      integration: pianobar
-      domain: media_player
   fields: {}
 
 tired_of_song:
   name: Tired of song
   description: Mark current song as tired (temporarily skip)
-  target:
-    entity:
-      integration: pianobar
-      domain: media_player
   fields: {}
 
 create_station:
   name: Create station
   description: Create a new station from the current song or artist
-  target:
-    entity:
-      integration: pianobar
-      domain: media_player
   fields:
     type:
       name: Type
@@ -47,10 +31,6 @@ create_station:
 rename_station:
   name: Rename station
   description: Rename an existing station
-  target:
-    entity:
-      integration: pianobar
-      domain: media_player
   fields:
     station_id:
       name: Station ID
@@ -68,10 +48,6 @@ rename_station:
 delete_station:
   name: Delete station
   description: Delete a station
-  target:
-    entity:
-      integration: pianobar
-      domain: media_player
   fields:
     station_id:
       name: Station ID
@@ -83,37 +59,21 @@ delete_station:
 reconnect:
   name: Reconnect
   description: Force reconnect to remote-pianobar WebSocket
-  target:
-    entity:
-      integration: pianobar
-      domain: media_player
   fields: {}
 
 explain_song:
   name: Explain song
   description: Get Pandora's explanation for why the current song was chosen
-  target:
-    entity:
-      integration: pianobar
-      domain: media_player
   fields: {}
 
 get_upcoming:
   name: Get upcoming songs
   description: Get list of upcoming songs in the queue
-  target:
-    entity:
-      integration: pianobar
-      domain: media_player
   fields: {}
 
 set_quick_mix:
   name: Set QuickMix
   description: Configure which stations are included in QuickMix
-  target:
-    entity:
-      integration: pianobar
-      domain: media_player
   fields:
     station_ids:
       name: Station IDs
@@ -125,10 +85,6 @@ set_quick_mix:
 add_seed:
   name: Add seed to station
   description: Add an artist or song as a seed to an existing station
-  target:
-    entity:
-      integration: pianobar
-      domain: media_player
   fields:
     music_id:
       name: Music ID
@@ -146,10 +102,6 @@ add_seed:
 get_station_info:
   name: Get station info
   description: Get station seeds and feedback history
-  target:
-    entity:
-      integration: pianobar
-      domain: media_player
   fields:
     station_id:
       name: Station ID
@@ -161,10 +113,6 @@ get_station_info:
 delete_seed:
   name: Delete seed from station
   description: Remove a seed from a station
-  target:
-    entity:
-      integration: pianobar
-      domain: media_player
   fields:
     seed_id:
       name: Seed ID
@@ -192,10 +140,6 @@ delete_seed:
 delete_feedback:
   name: Delete feedback
   description: Remove a thumbs up/down from station history
-  target:
-    entity:
-      integration: pianobar
-      domain: media_player
   fields:
     feedback_id:
       name: Feedback ID
@@ -213,10 +157,6 @@ delete_feedback:
 get_station_modes:
   name: Get station modes
   description: Get available playback modes for a station
-  target:
-    entity:
-      integration: pianobar
-      domain: media_player
   fields:
     station_id:
       name: Station ID
@@ -228,10 +168,6 @@ get_station_modes:
 set_station_mode:
   name: Set station mode
   description: Set the playback mode for a station
-  target:
-    entity:
-      integration: pianobar
-      domain: media_player
   fields:
     station_id:
       name: Station ID
@@ -252,28 +188,16 @@ set_station_mode:
 toggle_playback:
   name: Toggle playback
   description: Toggle between play and pause
-  target:
-    entity:
-      integration: pianobar
-      domain: media_player
   fields: {}
 
 reset_volume:
   name: Reset volume
   description: Reset volume to 50% default
-  target:
-    entity:
-      integration: pianobar
-      domain: media_player
   fields: {}
 
 search:
   name: Search for music
   description: Search for artists and songs
-  target:
-    entity:
-      integration: pianobar
-      domain: media_player
   fields:
     query:
       name: Search query
@@ -285,19 +209,11 @@ search:
 get_genres:
   name: Get genre categories
   description: Get list of genre categories for creating stations
-  target:
-    entity:
-      integration: pianobar
-      domain: media_player
   fields: {}
 
 create_station_from_music_id:
   name: Create station from music ID
   description: Create a new station from a search result or genre music ID
-  target:
-    entity:
-      integration: pianobar
-      domain: media_player
   fields:
     music_id:
       name: Music ID
@@ -309,10 +225,6 @@ create_station_from_music_id:
 add_shared_station:
   name: Add shared station
   description: Add a shared station by its numeric ID
-  target:
-    entity:
-      integration: pianobar
-      domain: media_player
   fields:
     station_id:
       name: Station ID


### PR DESCRIPTION
- Add optional entity_id parameter to service schemas (love_song, ban_song, tired_of_song, create_station, rename_station, delete_station, etc.) to allow targeting specific pianobar instances
- Improve coordinator lookup logic for multi-instance support
- Remove services.yaml (schema defined in code)