### PR TITLE
Add CONFIG_SCHEMA to fix integration validation warning

### DIFF
--- a/custom_components/pianobar/__init__.py
+++ b/custom_components/pianobar/__init__.py
@@ -43,6 +43,8 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [Platform.MEDIA_PLAYER, Platform.SELECT]
 
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
 
 def _get_coordinator_from_call(
     hass: HomeAssistant,


### PR DESCRIPTION
Use cv.config_entry_only_config_schema(DOMAIN) so HA validator recognizes integration is config-entry-only (no YAML config).

Made-with: Cursor