### PR TITLE
feat(ha): multi-account support (select entity, switch_account service)

### DIFF
--- a/custom_components/pianobar/__init__.py
+++ b/custom_components/pianobar/__init__.py
@@ -34,6 +34,7 @@ from .const import (
     SERVICE_SEARCH,
     SERVICE_SET_QUICK_MIX,
     SERVICE_SET_STATION_MODE,
+    SERVICE_SWITCH_ACCOUNT,
     SERVICE_TIRED_OF_SONG,
     SERVICE_TOGGLE_PLAYBACK,
 )
@@ -285,6 +286,15 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
             {"stationId": station_id}
         )
 
+    async def async_switch_account(call: ServiceCall) -> None:
+        """Handle switch_account service call."""
+        coordinator = _get_coordinator_from_call(hass, call)
+        account_id = call.data.get("account_id")
+        await coordinator.send_action_with_params(
+            "app.pandora-reconnect", {"account_id": account_id}
+        )
+        _LOGGER.info("Switching Pandora account to: %s", account_id)
+
     # Register all services (done once at domain level)
     hass.services.async_register(
         DOMAIN,
@@ -506,6 +516,16 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         schema=vol.Schema({
             vol.Optional("entity_id"): cv.entity_ids,
             vol.Required("station_id"): cv.string,
+        }),
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SWITCH_ACCOUNT,
+        async_switch_account,
+        schema=vol.Schema({
+            vol.Optional("entity_id"): cv.entity_ids,
+            vol.Required("account_id"): cv.string,
         }),
     )
 

--- a/custom_components/pianobar/const.py
+++ b/custom_components/pianobar/const.py
@@ -37,6 +37,7 @@ SERVICE_SEARCH = "search"
 SERVICE_GET_GENRES = "get_genres"
 SERVICE_CREATE_STATION_FROM_MUSIC_ID = "create_station_from_music_id"
 SERVICE_ADD_SHARED_STATION = "add_shared_station"
+SERVICE_SWITCH_ACCOUNT = "switch_account"
 
 # Media browser
 MEDIA_TYPE_STATION = "station"

--- a/custom_components/pianobar/coordinator.py
+++ b/custom_components/pianobar/coordinator.py
@@ -254,6 +254,12 @@ class PianobarCoordinator(DataUpdateCoordinator):
                 self.data["elapsed"] = payload["elapsed"]
                 self.data["position_updated_at"] = dt_util.utcnow()
 
+        # Multi-account state
+        if "accounts" in payload:
+            self.data["accounts"] = payload["accounts"]
+        if "current_account" in payload:
+            self.data["current_account"] = payload["current_account"]
+
     def _handle_start_event(self, payload: dict[str, Any]) -> None:
         """Handle start event (new song started)."""
         self.data.update({

--- a/custom_components/pianobar/media_player.py
+++ b/custom_components/pianobar/media_player.py
@@ -172,6 +172,9 @@ class PianobarMediaPlayer(CoordinatorEntity[PianobarCoordinator], MediaPlayerEnt
             ],
             # Full station data: id, name, isQuickMix, isQuickMixed
             "stations": self.coordinator.data.get("stations", []),
+            # Multi-account data for Lovelace card
+            "accounts": self.coordinator.data.get("accounts", []),
+            "current_account": self.coordinator.data.get("current_account"),
         }
         # Add rating and song station name from current song if available
         song = self.coordinator.data.get("song")

--- a/custom_components/pianobar/select.py
+++ b/custom_components/pianobar/select.py
@@ -20,9 +20,16 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Pianobar select entity."""
+    """Set up the Pianobar select entities."""
     coordinator: PianobarCoordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities([PianobarStationSelect(coordinator, entry)])
+    entities = [PianobarStationSelect(coordinator, entry)]
+
+    # Only add account select when multiple accounts are configured
+    accounts = coordinator.data.get("accounts", [])
+    if len(accounts) > 1:
+        entities.append(PianobarAccountSelect(coordinator, entry))
+
+    async_add_entities(entities)
 
 
 class PianobarStationSelect(CoordinatorEntity[PianobarCoordinator], SelectEntity):
@@ -68,5 +75,55 @@ class PianobarStationSelect(CoordinatorEntity[PianobarCoordinator], SelectEntity
             if station["name"] == option:
                 await self.coordinator.send_event("station.change", station["id"])
                 _LOGGER.debug("Changed station to: %s (ID: %s)", option, station["id"])
+                break
+
+
+class PianobarAccountSelect(CoordinatorEntity[PianobarCoordinator], SelectEntity):
+    """Select entity for Pianobar account switching."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Account"
+    _attr_icon = "mdi:account-switch"
+
+    def __init__(
+        self,
+        coordinator: PianobarCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the account select entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.entry_id}_account_select"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, entry.entry_id)},
+            "name": "Pianobar",
+            "manufacturer": "Pandora",
+            "model": "Pianobar",
+        }
+
+    @property
+    def options(self) -> list[str]:
+        """Return list of account labels."""
+        accounts = self.coordinator.data.get("accounts", [])
+        return [acct["label"] for acct in accounts]
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the currently active account label."""
+        current = self.coordinator.data.get("current_account")
+        if current:
+            label = current.get("label", current.get("id", ""))
+            if label in self.options:
+                return label
+        return None
+
+    async def async_select_option(self, option: str) -> None:
+        """Switch to the selected account."""
+        accounts = self.coordinator.data.get("accounts", [])
+        for acct in accounts:
+            if acct["label"] == option:
+                await self.coordinator.send_action_with_params(
+                    "app.pandora-reconnect", {"account_id": acct["id"]}
+                )
+                _LOGGER.debug("Switching to account: %s (ID: %s)", option, acct["id"])
                 break
 

--- a/custom_components/pianobar/services.yaml
+++ b/custom_components/pianobar/services.yaml
@@ -320,3 +320,18 @@ add_shared_station:
     entity:
       domain: media_player
       integration: pianobar
+
+switch_account:
+  name: Switch Pandora account
+  description: Switch to a different Pandora account (disconnects current session and reconnects with the specified account's credentials)
+  fields:
+    account_id:
+      name: Account ID
+      description: Account identifier as configured in pianobar config (e.g. "work", "default")
+      required: true
+      selector:
+        text:
+  target:
+    entity:
+      domain: media_player
+      integration: pianobar

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -106,6 +106,51 @@ async def test_handle_process_event(
     assert coordinator.data["song"] == mock_song_data
 
 
+async def test_handle_process_event_accounts_and_current_account(
+    hass: HomeAssistant,
+) -> None:
+    """Process payload includes multi-account fields."""
+    coordinator = PianobarCoordinator(hass, "127.0.0.1", 3000)
+    payload = {
+        "playing": False,
+        "paused": False,
+        "volume": 50,
+        "station": "",
+        "stationId": "",
+        "accounts": [{"id": "a", "label": "A"}, {"id": "b", "label": "B"}],
+        "current_account": {"id": "b", "label": "B"},
+    }
+    coordinator._handle_process_event(payload)
+    assert len(coordinator.data["accounts"]) == 2
+    assert coordinator.data["current_account"]["id"] == "b"
+
+
+async def test_handle_error_event_reconnect_last_station_deleted(
+    hass: HomeAssistant,
+) -> None:
+    """Reconnect error with last station removed updates list and current station."""
+    coordinator = PianobarCoordinator(hass, "127.0.0.1", 3000)
+    coordinator.data["stations"] = [
+        {"id": "gone", "name": "Gone"},
+        {"id": "keep", "name": "Keep"},
+    ]
+    coordinator.data["stationId"] = "gone"
+    coordinator.data["station"] = "Gone"
+
+    coordinator._handle_error_event(
+        {
+            "operation": "app.pandora-reconnect",
+            "message": "Last station was deleted",
+            "stationId": "gone",
+        }
+    )
+
+    assert len(coordinator.data["stations"]) == 1
+    assert coordinator.data["stations"][0]["id"] == "keep"
+    assert coordinator.data["stationId"] == ""
+    assert coordinator.data["station"] == ""
+
+
 async def test_handle_start_event(hass: HomeAssistant, mock_song_data) -> None:
     """Test handling start event."""
     coordinator = PianobarCoordinator(hass, "127.0.0.1", 3000)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,13 +1,16 @@
 """Test the Pianobar integration init."""
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import custom_components.pianobar as pianobar_integration
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import entity_registry as er
 
 from custom_components.pianobar.const import (
     DOMAIN,
@@ -31,6 +34,7 @@ from custom_components.pianobar.const import (
     SERVICE_SEARCH,
     SERVICE_SET_QUICK_MIX,
     SERVICE_SET_STATION_MODE,
+    SERVICE_SWITCH_ACCOUNT,
     SERVICE_TIRED_OF_SONG,
     SERVICE_TOGGLE_PLAYBACK,
 )
@@ -796,4 +800,132 @@ async def test_service_add_shared_station(
         call_args = mock_coordinator.send_event.call_args[0]
         assert call_args[0] == "station.addShared"
         assert call_args[1]["stationId"] == "1234567890"
+
+
+def test_get_coordinator_from_call_uses_first_entry_when_no_entity_id(
+    hass: HomeAssistant,
+    mock_config_entry: ConfigEntry,
+) -> None:
+    """Without entity_id, resolve coordinator from first config entry."""
+    coord_a = MagicMock()
+    coord_b = MagicMock()
+    hass.data[DOMAIN] = {
+        "first_id": coord_a,
+        "second_id": coord_b,
+    }
+    call = ServiceCall(DOMAIN, SERVICE_LOVE_SONG, {})
+    assert pianobar_integration._get_coordinator_from_call(hass, call) is coord_a
+
+
+def test_get_coordinator_from_call_raises_when_no_instances(hass: HomeAssistant) -> None:
+    """ServiceValidationError when domain has no coordinators."""
+    hass.data[DOMAIN] = {}
+    call = ServiceCall(DOMAIN, SERVICE_LOVE_SONG, {})
+    with pytest.raises(ServiceValidationError):
+        pianobar_integration._get_coordinator_from_call(hass, call)
+
+
+async def test_get_coordinator_from_call_resolves_entity_id(
+    hass: HomeAssistant,
+    mock_config_entry: ConfigEntry,
+) -> None:
+    """entity_id in service data maps to the correct coordinator."""
+    mock_config_entry.add_to_hass(hass)
+    coordinator = MagicMock()
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][mock_config_entry.entry_id] = coordinator
+
+    registry = er.async_get(hass)
+    reg_entry = registry.async_get_or_create(
+        "media_player",
+        DOMAIN,
+        mock_config_entry.entry_id,
+        suggested_object_id="pianobar_test_player",
+        config_entry=mock_config_entry,
+    )
+    await hass.async_block_till_done()
+
+    call = ServiceCall(
+        DOMAIN,
+        SERVICE_LOVE_SONG,
+        {"entity_id": reg_entry.entity_id},
+    )
+    assert pianobar_integration._get_coordinator_from_call(hass, call) is coordinator
+
+    call_list = ServiceCall(
+        DOMAIN,
+        SERVICE_LOVE_SONG,
+        {"entity_id": [reg_entry.entity_id]},
+    )
+    assert pianobar_integration._get_coordinator_from_call(hass, call_list) is coordinator
+
+
+async def test_service_reconnect_when_already_connected(
+    hass: HomeAssistant,
+    mock_config_entry: ConfigEntry,
+) -> None:
+    """Reconnect service does not call async_connect when already connected."""
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.pianobar.PianobarCoordinator"
+    ) as mock_coordinator_class:
+        mock_coordinator = mock_coordinator_class.return_value
+        mock_coordinator.async_connect = AsyncMock()
+        mock_coordinator.is_connected = True
+        mock_coordinator.data = {"playing": False}
+
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RECONNECT,
+            {},
+            blocking=True,
+        )
+
+        assert mock_coordinator.async_connect.call_count == 1
+
+
+async def test_service_switch_account(
+    hass: HomeAssistant,
+    mock_config_entry: ConfigEntry,
+) -> None:
+    """switch_account service sends app.pandora-reconnect with account_id."""
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.pianobar.PianobarCoordinator"
+    ) as mock_coordinator_class:
+        mock_coordinator = mock_coordinator_class.return_value
+        mock_coordinator.async_connect = AsyncMock()
+        mock_coordinator.send_action_with_params = AsyncMock()
+        mock_coordinator.data = {"playing": False}
+
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SWITCH_ACCOUNT,
+            {"account_id": "work"},
+            blocking=True,
+        )
+
+        mock_coordinator.send_action_with_params.assert_called_once_with(
+            "app.pandora-reconnect", {"account_id": "work"}
+        )
+
+
+async def test_async_reload_entry(
+    hass: HomeAssistant,
+    mock_config_entry: ConfigEntry,
+) -> None:
+    """Options update listener triggers config entry reload."""
+    with patch.object(
+        hass.config_entries, "async_reload", new=AsyncMock()
+    ) as mock_reload:
+        await pianobar_integration.async_reload_entry(hass, mock_config_entry)
+        mock_reload.assert_awaited_once_with(mock_config_entry.entry_id)
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -223,6 +223,36 @@ async def test_service_reconnect(
         assert mock_coordinator.async_connect.call_count == 2  # Once during setup, once for reconnect
 
 
+async def test_service_reconnect_async_connect_raises(
+    hass: HomeAssistant,
+    mock_config_entry: ConfigEntry,
+) -> None:
+    """Reconnect service logs error when async_connect fails."""
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.pianobar.PianobarCoordinator"
+    ) as mock_coordinator_class:
+        mock_coordinator = mock_coordinator_class.return_value
+        mock_coordinator.async_connect = AsyncMock(
+            side_effect=[None, RuntimeError("connection refused")]
+        )
+        mock_coordinator.is_connected = False
+        mock_coordinator.data = {"playing": False}
+
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RECONNECT,
+            {},
+            blocking=True,
+        )
+
+        assert mock_coordinator.async_connect.call_count == 2
+
+
 async def test_service_create_station(
     hass: HomeAssistant,
     mock_config_entry: ConfigEntry,
@@ -256,6 +286,34 @@ async def test_service_create_station(
         assert call_args[0] == "station.createFrom"
         assert call_args[1]["trackToken"] == "test_token"
         assert call_args[1]["type"] == "artist"
+
+
+async def test_service_create_station_without_track_token(
+    hass: HomeAssistant,
+    mock_config_entry: ConfigEntry,
+) -> None:
+    """create_station does nothing when no track token is available."""
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.pianobar.PianobarCoordinator"
+    ) as mock_coordinator_class:
+        mock_coordinator = mock_coordinator_class.return_value
+        mock_coordinator.async_connect = AsyncMock()
+        mock_coordinator.send_event = AsyncMock()
+        mock_coordinator.data = {"playing": False}
+
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CREATE_STATION,
+            {"type": "song"},
+            blocking=True,
+        )
+
+        mock_coordinator.send_event.assert_not_called()
 
 
 async def test_service_rename_station(

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -284,7 +284,8 @@ async def test_async_setup_entry_single_account_only_station_select(
 
     entities: list = []
 
-    async def async_add_entities(new_entities):
+    # AddEntitiesCallback is synchronous; platform calls it without await.
+    def async_add_entities(new_entities):
         entities.extend(new_entities)
 
     await async_setup_entry(hass, mock_config_entry, async_add_entities)
@@ -311,7 +312,7 @@ async def test_async_setup_entry_multi_account_adds_account_select(
 
     entities: list = []
 
-    async def async_add_entities(new_entities):
+    def async_add_entities(new_entities):
         entities.extend(new_entities)
 
     await async_setup_entry(hass, mock_config_entry, async_add_entities)

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,15 +1,20 @@
 """Tests for Pianobar select platform."""
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 
 from custom_components.pianobar.const import DOMAIN
-from custom_components.pianobar.select import PianobarStationSelect
+from custom_components.pianobar.select import (
+    PianobarAccountSelect,
+    PianobarStationSelect,
+    async_setup_entry,
+)
 
 
 @pytest.fixture
@@ -167,4 +172,151 @@ class TestPianobarStationSelect:
             "manufacturer": "Pandora",
             "model": "Pianobar",
         }
+
+
+@pytest.fixture
+def mock_coordinator_multi_account(mock_station_data):
+    """Coordinator data with two accounts (multi-account UI)."""
+    coordinator = MagicMock()
+    coordinator.data = {
+        "playing": True,
+        "paused": False,
+        "volume": 0,
+        "station": "Test Station 1",
+        "stationId": "123456789",
+        "stations": mock_station_data,
+        "accounts": [
+            {"id": "work", "label": "Work"},
+            {"id": "home", "label": "Home"},
+        ],
+        "current_account": {"id": "work", "label": "Work"},
+    }
+    coordinator.send_event = AsyncMock()
+    coordinator.send_action_with_params = AsyncMock()
+    coordinator.async_add_listener = MagicMock(return_value=lambda: None)
+    return coordinator
+
+
+class TestPianobarAccountSelect:
+    """Tests for PianobarAccountSelect entity."""
+
+    def test_account_entity_attributes(
+        self, mock_coordinator_multi_account, mock_config_entry_for_select
+    ):
+        """Account select uses correct name, icon, unique_id."""
+        entity = PianobarAccountSelect(
+            mock_coordinator_multi_account, mock_config_entry_for_select
+        )
+        assert entity.name == "Account"
+        assert entity.icon == "mdi:account-switch"
+        assert entity.unique_id == "test_entry_id_account_select"
+
+    def test_account_options_and_current(
+        self, mock_coordinator_multi_account, mock_config_entry_for_select
+    ):
+        """Options list labels; current_option matches active account."""
+        entity = PianobarAccountSelect(
+            mock_coordinator_multi_account, mock_config_entry_for_select
+        )
+        assert entity.options == ["Work", "Home"]
+        assert entity.current_option == "Work"
+
+    def test_current_option_falls_back_to_id_when_no_label(
+        self, mock_coordinator_multi_account, mock_config_entry_for_select
+    ):
+        """current_account without label uses id if that id is in options."""
+        mock_coordinator_multi_account.data["accounts"] = [
+            {"id": "solo", "label": "solo"},
+        ]
+        mock_coordinator_multi_account.data["current_account"] = {"id": "solo"}
+        entity = PianobarAccountSelect(
+            mock_coordinator_multi_account, mock_config_entry_for_select
+        )
+        assert entity.current_option == "solo"
+
+    def test_current_option_none_when_not_in_options(
+        self, mock_coordinator_multi_account, mock_config_entry_for_select
+    ):
+        """Unknown active account label yields None."""
+        mock_coordinator_multi_account.data["current_account"] = {
+            "id": "x",
+            "label": "Ghost",
+        }
+        entity = PianobarAccountSelect(
+            mock_coordinator_multi_account, mock_config_entry_for_select
+        )
+        assert entity.current_option is None
+
+    @pytest.mark.asyncio
+    async def test_account_async_select_option(
+        self, mock_coordinator_multi_account, mock_config_entry_for_select
+    ):
+        """Selecting an account sends app.pandora-reconnect with account_id."""
+        entity = PianobarAccountSelect(
+            mock_coordinator_multi_account, mock_config_entry_for_select
+        )
+        await entity.async_select_option("Home")
+        mock_coordinator_multi_account.send_action_with_params.assert_called_once_with(
+            "app.pandora-reconnect", {"account_id": "home"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_account_async_select_unknown_option(
+        self, mock_coordinator_multi_account, mock_config_entry_for_select
+    ):
+        """Unknown account label does not call send_action_with_params."""
+        entity = PianobarAccountSelect(
+            mock_coordinator_multi_account, mock_config_entry_for_select
+        )
+        await entity.async_select_option("Nope")
+        mock_coordinator_multi_account.send_action_with_params.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_single_account_only_station_select(
+    hass: HomeAssistant, mock_config_entry: ConfigEntry
+):
+    """One account configured: only station select entity."""
+    coordinator = MagicMock()
+    coordinator.data = {"stations": [], "accounts": [{"id": "a", "label": "Only"}]}
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][mock_config_entry.entry_id] = coordinator
+
+    entities: list = []
+
+    async def async_add_entities(new_entities):
+        entities.extend(new_entities)
+
+    await async_setup_entry(hass, mock_config_entry, async_add_entities)
+
+    assert len(entities) == 1
+    assert isinstance(entities[0], PianobarStationSelect)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_multi_account_adds_account_select(
+    hass: HomeAssistant, mock_config_entry: ConfigEntry
+):
+    """Two+ accounts: station select and account select."""
+    coordinator = MagicMock()
+    coordinator.data = {
+        "stations": [],
+        "accounts": [
+            {"id": "a", "label": "A"},
+            {"id": "b", "label": "B"},
+        ],
+    }
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][mock_config_entry.entry_id] = coordinator
+
+    entities: list = []
+
+    async def async_add_entities(new_entities):
+        entities.extend(new_entities)
+
+    await async_setup_entry(hass, mock_config_entry, async_add_entities)
+
+    assert len(entities) == 2
+    assert isinstance(entities[0], PianobarStationSelect)
+    assert isinstance(entities[1], PianobarAccountSelect)
 


### PR DESCRIPTION
- Track accounts and current_account from coordinator process payload
- Expose accounts on media player attributes for Lovelace card
- Add Account select entity when multiple accounts configured
- Register pianobar.switch_account service with entity targeting

Made-with: Cursor