### PR TITLE
fix(ha): connection cleanup and test runner docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,14 +597,17 @@ const isLoved = entity.attributes.rating === 1;
 
 ### Running Tests
 
-To run the test suite locally:
+To run the test suite locally, use **Python 3.11+** (see [TESTING.md](TESTING.md)):
 
 ```bash
-# Install test dependencies
+python3.11 -m venv .venv
+source .venv/bin/activate
 pip install -r requirements_test.txt
 
-# Run all tests
-pytest tests/
+# Run all tests (wrapper prefers .venv-py311, then .venv)
+./scripts/run_tests.sh tests/
+
+# Or: pytest tests/
 
 # Run tests with coverage
 pytest tests/ --cov=custom_components/pianobar --cov-report=term-missing

--- a/TESTING.md
+++ b/TESTING.md
@@ -14,11 +14,18 @@ This integration includes a comprehensive test suite with **100+ test cases** co
 
 ## Quick Start
 
+Use **Python 3.11+** and a virtualenv so `pytest-homeassistant-custom-component` can install Home Assistant test deps:
+
 ```bash
-# Install dependencies
+cd /path/to/remote-pianobar-ha
+python3.11 -m venv .venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
 pip install -r requirements_test.txt
 
-# Run all tests
+# Run all tests (uses .venv-py311 first, then .venv, then python3 — see scripts/run_tests.sh)
+./scripts/run_tests.sh tests/
+
+# Or explicitly:
 pytest tests/
 
 # Run with coverage report
@@ -27,6 +34,8 @@ pytest tests/ --cov=custom_components/pianobar --cov-report=html
 # View coverage report
 open htmlcov/index.html
 ```
+
+If `pytest` fails with `No module named 'homeassistant'`, recreate the venv with Python 3.11+ and reinstall `requirements_test.txt`.
 
 ## Test Modules
 

--- a/custom_components/pianobar/coordinator.py
+++ b/custom_components/pianobar/coordinator.py
@@ -62,8 +62,38 @@ class PianobarCoordinator(DataUpdateCoordinator):
         """Return True if WebSocket is connected."""
         return self._ws is not None and not self._ws.closed
 
+    async def _async_release_connection(self) -> None:
+        """Cancel listen task and close WebSocket + ClientSession."""
+        if self._listen_task:
+            self._listen_task.cancel()
+            try:
+                await self._listen_task
+            except asyncio.CancelledError:
+                pass
+            self._listen_task = None
+
+        if self._ws and not self._ws.closed:
+            await self._ws.close()
+        self._ws = None
+
+        if self._session and not self._session.closed:
+            await self._session.close()
+        self._session = None
+
+    async def _async_cleanup_failed_connect(self) -> None:
+        """Release resources after a failed connect; avoid leaking aiohttp sessions."""
+        # _listen() finally schedules reconnect only when not _is_closing; set True
+        # before cancelling the listen task so teardown does not spawn _reconnect().
+        self._is_closing = True
+        try:
+            await self._async_release_connection()
+        finally:
+            self._is_closing = False
+
     async def async_connect(self) -> None:
         """Connect to the WebSocket."""
+        # Allow reuse of this coordinator after partial teardown (e.g. failed setup retry).
+        self._is_closing = False
         self._initial_process_event.clear()
 
         if self._session is None:
@@ -106,23 +136,17 @@ class PianobarCoordinator(DataUpdateCoordinator):
             
         except asyncio.TimeoutError as err:
             _LOGGER.error("Timeout connecting to Pianobar")
+            await self._async_cleanup_failed_connect()
             raise ConnectionError("Connection timeout") from err
         except Exception as err:
             _LOGGER.error("Error connecting to Pianobar: %s", err)
+            await self._async_cleanup_failed_connect()
             raise ConnectionError(f"Connection error: {err}") from err
 
     async def async_disconnect(self) -> None:
         """Disconnect from the WebSocket."""
         self._is_closing = True
-        
-        if self._listen_task:
-            self._listen_task.cancel()
-            try:
-                await self._listen_task
-            except asyncio.CancelledError:
-                pass
-            self._listen_task = None
-            
+
         if self._reconnect_task:
             self._reconnect_task.cancel()
             try:
@@ -130,14 +154,8 @@ class PianobarCoordinator(DataUpdateCoordinator):
             except asyncio.CancelledError:
                 pass
             self._reconnect_task = None
-        
-        if self._ws and not self._ws.closed:
-            await self._ws.close()
-            self._ws = None
-            
-        if self._session and not self._session.closed:
-            await self._session.close()
-            self._session = None
+
+        await self._async_release_connection()
 
     async def _listen(self) -> None:
         """Listen for WebSocket messages."""
@@ -163,6 +181,21 @@ class PianobarCoordinator(DataUpdateCoordinator):
                 # Clear playback state on connection loss so player cards reset
                 self._clear_playback_state()
                 self.async_set_updated_data(self.data)
+                # Drop stale reconnect loop if still running; release dead socket before retry.
+                if self._reconnect_task and not self._reconnect_task.done():
+                    self._reconnect_task.cancel()
+                    try:
+                        await self._reconnect_task
+                    except asyncio.CancelledError:
+                        pass
+                    self._reconnect_task = None
+                if self._ws is not None:
+                    try:
+                        if not self._ws.closed:
+                            await self._ws.close()
+                    except Exception:
+                        pass
+                    self._ws = None
                 self._reconnect_task = asyncio.create_task(self._reconnect())
 
     async def _reconnect(self) -> None:

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Run pytest using a project venv when present (recommended).
+# Prefer .venv-py311 (matches CI Python 3.11+); a plain .venv may be an older
+# Python without homeassistant — see TESTING.md.
+# Falls back to python3 -m pytest.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if [[ -x "${ROOT}/.venv-py311/bin/python" ]]; then
+  exec "${ROOT}/.venv-py311/bin/python" -m pytest "$@"
+elif [[ -x "${ROOT}/.venv/bin/python" ]]; then
+  exec "${ROOT}/.venv/bin/python" -m pytest "$@"
+else
+  exec python3 -m pytest "$@"
+fi


### PR DESCRIPTION
- coordinator: release aiohttp session/ws on failed async_connect; reset _is_closing for retries; cancel stale reconnect and close dead ws in _listen finally; reorder async_disconnect to cancel reconnect before release
- scripts/run_tests.sh: prefer .venv-py311 then .venv then python3
- TESTING.md / README: Python 3.11+ venv and run_tests.sh usage

Made-with: Cursor